### PR TITLE
[ADD] 아이템 충돌시 내구도 감소 기능 추가

### DIFF
--- a/Assets/Resource/Prefabs/Item/ToolResources/OriginIron.prefab
+++ b/Assets/Resource/Prefabs/Item/ToolResources/OriginIron.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 483599495691224854}
   - component: {fileID: 8546266700257129831}
   - component: {fileID: 6278714287063364188}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: OriginIron
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -130,7 +130,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4174441860887072748}
   - component: {fileID: 8304838098107239511}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: OriginIron
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Item/ItemData.cs
+++ b/Assets/Scripts/Item/ItemData.cs
@@ -17,7 +17,6 @@ public enum ConsumableType
     Thirsty,
     Speed,
     Strength,
-    Durability,
     isZombie
 }
 

--- a/Assets/Scripts/Item/ItemDurability.cs
+++ b/Assets/Scripts/Item/ItemDurability.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemDurability : MonoBehaviour
+{
+    [SerializeField]
+    GameObject item;
+    ItemObject itemObject;
+    public int durability = 100;
+
+
+    private void Awake()
+    {
+        itemObject = item.GetComponent<ItemObject>();
+
+    }  
+    
+
+    //좀비 또는 originIron과 충돌하면 내구도 10씩 감소
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        //좀비와 충돌했을 때도 추가 예정
+        if(collision.gameObject.name == "OriginIron")
+        {
+            durability -= 10;
+
+            if(durability <= 0)
+            {
+                Destroy(item);
+                //인벤토리서도 없어지나?
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Item/ItemDurability.cs.meta
+++ b/Assets/Scripts/Item/ItemDurability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5480993170ee4ab3b11816bc4c14ed6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- 장비 아이템이 originIron/좀비와 충돌시 내구도 감소(좀비 충돌은 처리해야 함)
- 해머로 originIron 5번 때릴 경우 철 5개 등장하면서 originIron은 사라짐.